### PR TITLE
gcode.h: add missing `<cstdint>` include

### DIFF
--- a/gcode.h
+++ b/gcode.h
@@ -4,6 +4,7 @@
 
 
 // Header files
+#include <cstdint>
 #include <iostream>
 #include <vector>
 


### PR DESCRIPTION
Without the change build fails on `gcc-13` as:

    gcode.h:54:24: error: 'uint8_t' was not declared in this scope
       54 |                 vector<uint8_t> getBinary() const;
          |                        ^~~~~~~
    gcode.h:9:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
        8 | #include <vector>
      +++ |+#include <cstdint>
        9 |